### PR TITLE
fix: twitter-search couldn't access elasticsearch due to cors issues

### DIFF
--- a/dockerfiles/latest/docker-compose.yml
+++ b/dockerfiles/latest/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     - cluster.name=docker-cluster
     - bootstrap.memory_lock=true
     - "ES_JAVA_OPTS=${ELASTIC_JAVA_OPTS}"
+    - http.cors.enabled=true
+    - http.cors.allow-origin=*
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
Resolves the following issue:

![image](https://user-images.githubusercontent.com/1043668/81963674-b26a1e00-9615-11ea-902b-9495acbaf310.png)

Inspired by:

- https://github.com/elastic/elasticsearch/issues/9031#issuecomment-257235528